### PR TITLE
Remove git commands

### DIFF
--- a/lib/tasks/grade.rake
+++ b/lib/tasks/grade.rake
@@ -63,10 +63,9 @@ namespace :grade do
         `bin/rails db:migrate RAILS_ENV=test`
         `RAILS_ENV=test bundle exec rspec --order default --format JsonOutputFormatter --out #{path}`
         rspec_output_json = JSON.parse(File.read(path))
-        git_url = `git config --get remote.origin.url`.chomp
-        username = git_url.split(':')[1].split('/')[0]
-        reponame =  git_url.split(':')[1].split('/')[1].sub(".git", "")
-        sha = `git rev-parse --verify HEAD`.chomp
+        username = ""
+        reponame = ""
+        sha = ""
 
         GradeRunner::Runner.new(submission_url, token, rspec_output_json, username, reponame, sha, "manual").process
       end


### PR DESCRIPTION
Addressing [#119](https://github.com/firstdraft/appdev/issues/119)

[When submitting to `grades`](https://github.com/firstdraft/grade_runner/blob/5252413c49ead8ad21ca456bf6650d92d54433d8/lib/tasks/grade.rake#L66),  `grade_runner` uses git to do the following:

1. Find the username of the User
2. Find the name of the repo
3. Get the SHA1 Hash

None of these `git` commands are being used in `grades` currently, so this branch makes those params blank..