### PR TITLE
Use Oj to parse json to prevent UTF conversion errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 # Add dependencies required to use your gem here.
 # Example:
 #   gem "activesupport", ">= 2.3.5"
-
+gem "oj"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    oj (3.10.6)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -102,6 +103,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.0)
   juwelier (~> 2.1.0)
+  oj
   pry (~> 0)
   pry-byebug (~> 3)
   pry-doc (~> 0)
@@ -113,4 +115,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/grade_runner.gemspec
+++ b/grade_runner.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new("> 1.3.1".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Raghu Betina".freeze]
-  s.date = "2019-06-26"
+  s.date = "2020-04-08"
   s.description = "This gem runs your RSpec test suite and posts the JSON output to grades.firstdraft.com.".freeze
   s.email = "raghu@firstdraft.com".freeze
   s.extra_rdoc_files = [
@@ -37,13 +37,14 @@ Gem::Specification.new do |s|
   ]
   s.homepage = "http://github.com/firstdraft/grade_runner".freeze
   s.licenses = ["MIT".freeze]
-  s.rubygems_version = "2.7.8".freeze
+  s.rubygems_version = "3.0.6".freeze
   s.summary = "A Ruby client for [firstdraft Grades](https://grades.firstdraft.com)".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<oj>.freeze, [">= 0"])
       s.add_development_dependency(%q<rspec>.freeze, ["~> 3.5.0"])
       s.add_development_dependency(%q<rdoc>.freeze, ["~> 3.12"])
       s.add_development_dependency(%q<bundler>.freeze, ["~> 1.0"])
@@ -56,6 +57,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<pry-rescue>.freeze, ["~> 1"])
       s.add_development_dependency(%q<pry-stack_explorer>.freeze, ["~> 0"])
     else
+      s.add_dependency(%q<oj>.freeze, [">= 0"])
       s.add_dependency(%q<rspec>.freeze, ["~> 3.5.0"])
       s.add_dependency(%q<rdoc>.freeze, ["~> 3.12"])
       s.add_dependency(%q<bundler>.freeze, ["~> 1.0"])
@@ -69,6 +71,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<pry-stack_explorer>.freeze, ["~> 0"])
     end
   else
+    s.add_dependency(%q<oj>.freeze, [">= 0"])
     s.add_dependency(%q<rspec>.freeze, ["~> 3.5.0"])
     s.add_dependency(%q<rdoc>.freeze, ["~> 3.12"])
     s.add_dependency(%q<bundler>.freeze, ["~> 1.0"])

--- a/lib/grade_runner/runner.rb
+++ b/lib/grade_runner/runner.rb
@@ -1,4 +1,6 @@
 require "net/http"
+require "oj"
+
 module GradeRunner
   class Runner
 
@@ -27,7 +29,8 @@ module GradeRunner
       res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
         http.request(req)
       end
-      results_url = JSON.parse(res.body)["url"]
+
+      results_url = Oj.load(res.body)["url"]
       puts "- Done! Results URL: " + "#{results_url}"
     end
 

--- a/lib/tasks/grade.rake
+++ b/lib/tasks/grade.rake
@@ -54,6 +54,7 @@ namespace :grade do
     end
     
     if token.present? 
+
       if is_valid_token?(submission_url, token) == false
         student_config["personal_access_token"] = nil
         update_config_file(config_file_name, student_config)
@@ -62,7 +63,7 @@ namespace :grade do
         path = Rails.root.join("/tmp/output/#{Time.now.to_i}.json")
         `bin/rails db:migrate RAILS_ENV=test`
         `RAILS_ENV=test bundle exec rspec --order default --format JsonOutputFormatter --out #{path}`
-        rspec_output_json = JSON.parse(File.read(path))
+        rspec_output_json = Oj.load(File.read(path))
         username = ""
         reponame = ""
         sha = ""
@@ -100,7 +101,7 @@ def is_valid_token?(root_url, token)
   res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
     http.request(req)
   end
-  result = JSON.parse(res.body)
+  result = Oj.load(res.body)
   result["success"]
 rescue => e
   return false


### PR DESCRIPTION
This is part 2 of the changes that fix `rails grade` from failing to parse emojis. Part 1 is related to `JsonOutputFormatter` [here](https://github.com/firstdraft/appdev_template/pull/120).

Even _if_ `rspec` can output JSON with emojis, `rails grade` will **still** fail because Ruby cannot _read_ the emojis within the JSON.


```ruby
rspec --format JsonOutputFormmater --out path
rspec_output_json = JSON.parse(File.read(path))
```

```bash
JSON::ParserError: 767: unexpected token
```

Proposed changes are to rely on the `oj` gem to parse any emojis.

```ruby
rspec_output_json = Oj.load(File.read(path))
```

You can test the changes by updating the `json_output_formatter.rb` in the workspace you made from that PR and update your `Gemfile` to have

```ruby
gem 'grade_runner', github: 'firstdraft/grade_runner', branch: "jw-use-oj-to-parse-json"
```
under development and `bundle update`.

The same code that used to fail now succeeds when you run `rails grade`.