### PR TITLE
Add rake task to reset access token

### DIFF
--- a/lib/tasks/grade.rake
+++ b/lib/tasks/grade.rake
@@ -90,6 +90,35 @@ namespace :grade do
     end
   end
 
+  desc "Reset access token saved in YAML file."
+  task :reset_token do
+    config_dir_name = find_or_create_config_dif
+    config_file_name = "#{config_dir_name}/.ltici_apitoken.yml"
+    submission_url = "https://grades.firstdraft.com"
+
+    student_config = {}
+    student_config["submission_url"] = submission_url
+    puts "Enter your access token for this project"
+    new_personal_access_token = ""
+
+    while new_personal_access_token == "" do
+      print "> "
+      new_personal_access_token = $stdin.gets.chomp.strip
+      token_valid = is_valid_token?(submission_url, new_personal_access_token)
+      unless token_valid && !new_personal_access_token.empty?
+        puts "Please enter valid token"
+        new_personal_access_token = ""
+      end
+
+      unless new_personal_access_token.empty?
+        student_config["personal_access_token"] = new_personal_access_token
+        update_config_file(config_file_name, student_config)
+        token = new_personal_access_token
+      end
+    end
+    puts "Grade token has been reset successfully."
+  end
+
 end
 
 def update_config_file(config_file_name, config)


### PR DESCRIPTION
Resolves #23 

## Problem

Sometimes a student will get into a situation where they have the wrong token and we need to reset it, which currently is not easy to do.

> I was able to verify that this student was somehow able to launch an assignment that they're no longer able to view.
> (They're a part of the Thursday section, but have a 10/10 for the Tuesday section assignment)
> I assume this happened b/c the assignment was briefly available to all student, but then was updated so only Tuesday section students could view.
> The student must have launched the assignment before this change happened and, while they probably only see one rps-html assignment in their canvas (thursday section), they already created a workspace associated with the Tuesday section so the grade was updated in an assignment they don't have access to.

>You can do some finagling to figure out their grade access token for the correct assignment (the thurs section in this case) and together with the student update the token in the hidden file .vscode/.ltici_apitoken.yml with the new token. Then they run rails grade again.
> You can figure out the token by asking the student to tell you or looking it up in the grades production db

## Solution

Add a rake task that students can run to reset their own token.

