### PR TITLE
Remove 'posting to url' copy

### DIFF
--- a/lib/grade_runner/runner.rb
+++ b/lib/grade_runner/runner.rb
@@ -22,7 +22,6 @@ module GradeRunner
     private
 
     def post_to_grades
-      puts "- Posting to URL: " + "#{@submission_url}"
       uri = URI.parse(@submission_url)
       req = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
       req.body = data.to_json


### PR DESCRIPTION
Currently, `rails grade` prints something like "Posting to URL: grades.firstdraft.com/builds" before it prints the actual URL of the build, leading many students to click on the wrong URL and then get confused.

This patch drops the confusing print statement.