### PR TITLE
Fetch URL from Grades using token

### DIFF
--- a/lib/tasks/grade.rake
+++ b/lib/tasks/grade.rake
@@ -69,6 +69,7 @@ namespace :grade do
         puts "Your access token looked invalid, so we've reset it to be blank. Please re-run rails grade and, when asked, copy-paste your token carefully from the assignment page."
       else
         full_reponame = upstream_repo(submission_url, token)
+        set_upstream_remote(full_reponame)
         sync_specs_with_source(full_reponame)
 
         path = File.join(project_root, "/tmp/output/#{Time.now.to_i}.json")
@@ -131,10 +132,6 @@ namespace :grade do
 end
 
 def sync_specs_with_source(full_reponame)
-  # reponame = `basename -s .git \`git config --get remote.origin.url\``.chomp
-  # full_reponame = "appdev-projects/#{reponame}"
-  # root_url = "https://grades.firstdraft.com"
-  
   if Octokit.repository?(full_reponame)
     repo_contents = Octokit.contents(full_reponame)
     remote_spec_folder = repo_contents.find { |git_object| git_object[:name] == 'spec' }
@@ -148,7 +145,7 @@ def sync_specs_with_source(full_reponame)
     local_sha = `git ls-tree HEAD #{project_root.join('spec')}`.chomp.split[2]
 
     unless remote_sha == local_sha
-      `git fetch upstream`
+      `git fetch upstream -q`
       # Remove local contents of spec folder
       `rm -rf spec/*`
       default_branch = `git remote show upstream | grep 'HEAD branch' | cut -d' ' -f5`.chomp
@@ -157,6 +154,15 @@ def sync_specs_with_source(full_reponame)
     end
   else
     abort("The project #{full_reponame} does not exist.")
+  end
+end
+
+def set_upstream_remote(repo_slug)
+  upstream = `git remote -v | grep -w upstream`.chomp
+  if upstream.blank?
+    `git remote add upstream https://github.com/#{repo_slug}`
+  else
+    `git remote set-url upstream https://github.com/#{repo_slug}`
   end
 end
 
@@ -184,7 +190,7 @@ rescue => e
   return false
 end
 
-def upstream_repo?(root_url, token)
+def upstream_repo(root_url, token)
   return false unless token.is_a?(String) && token =~ /^[1-9A-Za-z][^OIl]{23}$/
   url = "#{root_url}/submissions/resource?token=#{token}"
   uri = URI.parse(url)
@@ -193,7 +199,7 @@ def upstream_repo?(root_url, token)
     http.request(req)
   end
   result = Oj.load(res.body)
-  result["repo_owner"] + "/" + result["repo_name"]
+  result["repo_slug"]
 rescue => e
   return false
 end


### PR DESCRIPTION
Related to https://github.com/firstdraft/grades/pull/676

Resolves [FIR-339](https://linear.app/firstdraft/issue/FIR-339/grade-runner-call-grades-api-to-determine-which-repo-to-use-specs-from)

## Problem

With the higher probability that students will rename their repos, the changes to grade_runner that allow tests to pull from the latest upstream will no longer work, since the repo names could differ.

In order to allow grade_runner to know which specs to use, grade_runner needs to ask Grades to provide the correct repo URL using the submission token.

## Solution

Use new Grades endpoint to determine and or set the correct upstream URL for the current project.

### Demo

Testing with:
- a local version of Grades (with changes from [#676](https://github.com/firstdraft/grades/pull/676) checkedout)
  - the access token points to `appdev-projects/string-chapter`
- in a local clone of `string-chapter`, renamed to `strang-chapter`
  - `upstream` remote does not exist
  - spec has been modified and committed

![grade_runner - test new grades endpoint](https://github.com/firstdraft/grade_runner/assets/17581658/b168b9fd-851f-4864-ae95-dcdfc763dbb6)

I'm deferring some cleanup to #69 