### PR TITLE
Make git credentials optional

### DIFF
--- a/lib/tasks/grade.rake
+++ b/lib/tasks/grade.rake
@@ -205,6 +205,7 @@ rescue => e
 end
 
 def github_username(primary_email)
+  return "" if primary_email.blank?
   username = `git config user.name`.chomp
   search_results = Octokit.search_users("#{primary_email} in:email").fetch(:items)
   if search_results.present?


### PR DESCRIPTION
Resolves #73 #74 

## Problem

A recent Gitpod change has made it so Git credentials (`user.email` and `user.name`) are no longer automatically set.

This causes a problem because the email and username are used when submitting results to grades.firstdraft.com. Without them, the task fails.

## Solution

Make the git credentials optional.

### Test instructions

- Update Gemfile in grade-able project

```rb
gem "grade_runner", github: "firstdraft/grade_runner", branch: "73-optionally-allow-git-credentials"
```
- Open in Gitpod
- Ensure Git credentials are not set (use `git config --list`)
- Run `rake grade`
