### PR TITLE
Improve how incorrect project tokens are handled

### DIFF
--- a/lib/tasks/grade.rake
+++ b/lib/tasks/grade.rake
@@ -151,6 +151,11 @@ def sync_specs_with_source(full_reponame)
       default_branch = `git remote show upstream | grep 'HEAD branch' | cut -d' ' -f5`.chomp
       # Overwrite local contents of spec folder with contents from upstream branch
       `git checkout upstream/#{default_branch} spec/ -q`
+      # Unstage new spec file contents
+      # - if wrong token is used, spec files can be removed properly when unstaged
+      # - spec file changes committed by learner are removed and updated
+      # - we are not committing spec file changes by default to avoid confusing the git history
+      `git restore --staged spec/*`
     end
   else
     abort("The project #{full_reponame} does not exist.")


### PR DESCRIPTION
Resolves #78 
Resolves #79

Previously, unstaged and committed changes to the spec folder were removed before downloading the contents from the remote repo. This had the affect of staging the new spec file contents and preventing them from being removed is the token was updated later. This commit updates the logic related to syncing the remote spec files to unstage the new file contents. This allows the process of updating the grade token to work indefinitely while preserving the current behavior of discarding unstaged and committed changes. The other approach of committing the new spec folder contents was not implemented to avoid confusing learning with a git history that they did not explicitly create.